### PR TITLE
IT-3921: Rebuild container when Trivy code scan fails

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -87,4 +87,7 @@ jobs:
         with:
           sarif_file: ${{ env.sarif_file_name  }}
           wait-for-processing: true
+
+    outputs:
+      trivy_conclusion: steps.trivy.outputs.conclusion
 ...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -32,4 +32,18 @@ jobs:
       # While GitHub repo's can be mixed (upper and lower) case,
       # Docker images can only be lower case
       IMAGE_NAME: ${{ needs.to-lower-case.outputs.lowercase-repo-name }}
+      EXIT_CODE: 1
+
+  # If scan failed, rebuild the image
+  update-image:
+    needs: periodic-scan
+    runs-on: ubuntu-latest
+    if: ${{needs.periodic-scan.outputs.trivy_conclusion == 'failure' }}
+    # tag the repo to trigger a new build
+    steps:
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 ...


### PR DESCRIPTION
This repo' runs a daily scan of the built container image using Trivy and reports its findings to on the repo's Security tab.  When findings appear they can almost always be addressed simply by rebuilding the image, which picks up updates to the dependencies.  In this way rebuilding the Docker image is analogous to patching a linux server.

This PR adds logic to the daily scan to automatically trigger a rebuild of the image when the scan fails, by incrementing the semvar tag.  If the rebuild is successful an updated image will be pushed to ghcr.io.  If the rebuild fails to address the findings then no new image will be pushed, and instead the IT team will see the findings in the Security tab, and investigate, following our current process.