### PR TITLE
IT-3921: Fix periodic image scan and image rebuild

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -87,4 +87,7 @@ jobs:
         with:
           sarif_file: ${{ env.sarif_file_name  }}
           wait-for-processing: true
+
+    outputs:
+      trivy_conclusion: steps.trivy.outputs.conclusion
 ...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -32,4 +32,18 @@ jobs:
       # While GitHub repo's can be mixed (upper and lower) case,
       # Docker images can only be lower case
       IMAGE_NAME: ${{ needs.to-lower-case.outputs.lowercase-repo-name }}
+      EXIT_CODE: 1
+
+  # If scan failed, rebuild the image
+  update-image:
+    needs: periodic-scan
+    runs-on: ubuntu-latest
+    if: ${{needs.periodic-scan.outputs.trivy_conclusion == 'failure' }}
+    # tag the repo to trigger a new build
+    steps:
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 ...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -38,7 +38,7 @@ jobs:
   update-image:
     needs: periodic-scan
     runs-on: ubuntu-latest
-    if: ${{needs.periodic-scan.outputs.trivy_conclusion == 'failure' }}
+    if: ${{!cancelled() && needs.periodic-scan.outputs.trivy_conclusion == 'failure' }}
     # tag the repo to trigger a new build
     steps:
       - name: Bump version and push tag


### PR DESCRIPTION
This PR has two changes:
(1)   Downloading the trivy-db from its default GitHub location fails because the site experiences too many downloads.  The fix is to pull from an alternate location, hosted in AWS ECR;
(2) The logic to rebuild the image when the Trivy job fails didn't work.  The evidence is [here](https://github.com/Sage-Bionetworks-IT/rstudio-service-catalog/actions/runs/11622790973/job/32368831154).  The `if` condition for the `update-image` job needs to start with `always() &&` or, alternatively, `!cancelled() &&`.  While logically adding `TRUE &&` should make no change, this is required for GitHub Workflows to work correctly, as discussed [here](https://stackoverflow.com/questions/58858429/how-to-run-a-github-actions-step-even-if-the-previous-step-fails-while-still-f).