### PR TITLE
IT-3921: Fix periodic scan

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -87,4 +87,7 @@ jobs:
         with:
           sarif_file: ${{ env.sarif_file_name  }}
           wait-for-processing: true
+
+    outputs:
+      trivy_conclusion: steps.trivy.outputs.conclusion
 ...

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -24,6 +24,10 @@ on:
         required: false
         type: number
         default: 0
+    outputs:
+      trivy_conclusion:
+        description: "The pass/fail return code from Trivy"
+        value: ${{ jobs.trivy.outputs.trivy_conclusion }}
 
 env:
   sarif_file_name: trivy-results.sarif
@@ -94,5 +98,5 @@ jobs:
           wait-for-processing: true
 
     outputs:
-      trivy_conclusion: steps.trivy.outputs.conclusion
+      trivy_conclusion: steps.trivy.conclusion
 ...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -9,8 +9,10 @@ name: Trivy Periodic Image Scan
 
 on:
   schedule:
+    # run hourly (testing)
+    - cron: "0 * * * *"
     # run daily
-    - cron: "0 0 * * *"
+    #- cron: "0 0 * * *"
 
 jobs:
   to-lower-case:

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -32,4 +32,18 @@ jobs:
       # While GitHub repo's can be mixed (upper and lower) case,
       # Docker images can only be lower case
       IMAGE_NAME: ${{ needs.to-lower-case.outputs.lowercase-repo-name }}
+      EXIT_CODE: 1
+
+  # If scan failed, rebuild the image
+  update-image:
+    needs: periodic-scan
+    runs-on: ubuntu-latest
+    if: ${{needs.periodic-scan.outputs.trivy_conclusion == 'failure' }}
+    # tag the repo to trigger a new build
+    steps:
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 ...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -9,10 +9,8 @@ name: Trivy Periodic Image Scan
 
 on:
   schedule:
-    # run hourly (testing)
-    - cron: "0 * * * *"
     # run daily
-    #- cron: "0 0 * * *"
+    - cron: "0 0 * * *"
 
 jobs:
   to-lower-case:

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -38,7 +38,7 @@ jobs:
   update-image:
     needs: periodic-scan
     runs-on: ubuntu-latest
-    if: ${{needs.periodic-scan.outputs.trivy_conclusion == 'failure' }}
+    if: ${{!cancelled() && needs.periodic-scan.outputs.trivy_conclusion == 'failure' }}
     # tag the repo to trigger a new build
     steps:
       - name: Bump version and push tag


### PR DESCRIPTION
Two fixes:
(1) When referring to the output of a callable workflow we have to reference the output of the workflow not of a job in the workflow. This PR adds the workflow output, `trivy_conclusion` so it can be referenced by the caller;
(2) When referring to the `conclusion` of a step it's `step.conclusion` not `step.output.conclusion`.