### PR TITLE
Rebuild Docker image when Trivy scan fails

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -74,6 +74,9 @@ jobs:
         with:
           ref: ${{ inputs.REF_TO_CHECKOUT }}
 
+      - name: debug
+        run: echo REF_TO_CHECKOUT ${{ inputs.REF_TO_CHECKOUT }}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6.4.0
         with:

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -79,5 +79,5 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ fromJSON(inputs.IMAGE_REFERENCES) }}
+          tags: ${{ inputs.IMAGE_REFERENCES }}
 ...

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -74,11 +74,6 @@ jobs:
         with:
           ref: ${{ inputs.REF_TO_CHECKOUT }}
 
-      - name: debug
-        run: |
-          echo IMAGE_REFERENCES ${{ inputs.REF_TO_CHECKOUT }}
-          echo IMAGE_REFERENCES ${{ inputs.IMAGE_REFERENCES }}
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v6.4.0
         with:

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -75,7 +75,7 @@ jobs:
           ref: ${{ inputs.REF_TO_CHECKOUT }}
 
       - name: debug
-        run: echo REF_TO_CHECKOUT ${{ inputs.REF_TO_CHECKOUT }}
+        run: echo IMAGE_REFERENCES ${{ inputs.IMAGE_REFERENCES }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6.4.0

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -2,20 +2,19 @@
 name: Run precommit and conditionally build container
 
 on:
-  push:
-    branches:
-      - '*'
-    tags:
-      - 'v[0-9]+\.[0-9]+\.[0-9]+'
-  pull_request:
-    branches:
-      - '*'
+  workflow_call:
+    inputs:
+      REF_TO_CHECKOUT:
+        required: false
+        type: string
+        description: reference to checkout, e.g. a tag like v1.0.1.  Defaults to the branch/tag of the current event.
+      IMAGE_REFERENCES:
+        required: true
+        type: string
+        description: "image references, e.g., ['ghcr.io/sage-bionetworks/rstudio-service-catalog:1.0.1']"
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_PATH: ghcr.io/${{ github.repository }}
   TARFILE_NAME: image.tar
-
 
 jobs:
   tests:
@@ -23,20 +22,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.REF_TO_CHECKOUT }}
 
       - name: Static Analysis
         uses: pre-commit/action@v3.0.0
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4.1.1
-        with:
-          images: ${{ env.IMAGE_PATH }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}} # major.minor.patch
-            type=semver,pattern={{major}}.{{minor}}
 
       - name: Check that build works, save for scanning, but don't push yet
         uses: docker/build-push-action@v6.4.0
@@ -44,8 +34,6 @@ jobs:
           context: .
           push: false
           outputs: type=tar,dest=${{ env.TARFILE_NAME }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
 
       - name: Upload tarball for use by Trivy job
         uses: actions/upload-artifact@v4
@@ -54,7 +42,6 @@ jobs:
           path: ${{ env.TARFILE_NAME }}
 
     outputs:
-      meta_json: ${{ steps.meta.outputs.json }}
       tarfile_artifact: ${{ env.TARFILE_NAME }}
 
   trivy-scan:
@@ -73,9 +60,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    strategy:
-      matrix:
-        value: ${{ fromJSON(needs.tests.outputs.meta_json).tags }}
 
     steps:
       - name: Login to GitHub Container Registry
@@ -87,11 +71,13 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.REF_TO_CHECKOUT }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6.4.0
         with:
           context: .
           push: true
-          tags: ${{ matrix.value }}
+          tags: ${{ fromJSON(inputs.IMAGE_REFERENCES) }}
 ...

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -54,7 +54,7 @@ jobs:
       EXIT_CODE: 1
 
   push-image:
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
     needs: [tests, trivy-scan]
     runs-on: ubuntu-latest
     permissions:
@@ -75,7 +75,9 @@ jobs:
           ref: ${{ inputs.REF_TO_CHECKOUT }}
 
       - name: debug
-        run: echo IMAGE_REFERENCES ${{ inputs.IMAGE_REFERENCES }}
+        run: |
+          echo IMAGE_REFERENCES ${{ inputs.REF_TO_CHECKOUT }}
+          echo IMAGE_REFERENCES ${{ inputs.IMAGE_REFERENCES }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6.4.0

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -11,7 +11,7 @@ on:
       IMAGE_REFERENCES:
         required: true
         type: string
-        description: "image references, e.g., ['ghcr.io/sage-bionetworks/rstudio-service-catalog:1.0.1']"
+        description: "image references, e.g., ghcr.io/sage-bionetworks/rstudio-service-catalog:1.0.1"
 
 env:
   TARFILE_NAME: image.tar

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,10 @@ jobs:
             type=semver,pattern={{version}} # major.minor.patch
             type=semver,pattern={{major}}.{{minor}}
 
+      - name: debug
+        run: |
+          echo steps.meta.tags ${{ steps.meta.tags }}
+
     outputs:
       tags: ${{ steps.meta.tags }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,10 +31,10 @@ jobs:
 
       - name: debug
         run: |
-          echo steps.meta.tags ${{ steps.meta.tags }}
+          echo steps.meta.outputs.tags ${{ steps.meta.outputs.tags }}
 
     outputs:
-      tags: ${{ steps.meta.tags }}
+      tags: ${{ steps.meta.outputs.tags }}
 
   docker-build:
     needs: get-tags

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,6 @@ jobs:
     needs: get-tags
     uses: "./.github/workflows/docker_build.yml"
     with:
-      IMAGE_REFERENCES: ${{ toJSON(fromJSON(needs.get-tags.outputs.meta_json).tags)} }}
+      IMAGE_REFERENCES: ${{ toJSON(fromJSON(needs.get-tags.outputs.meta_json).tags) }}
 
 ...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 ---
-name: Run precommit and conditionally build container
+name: Determine the Docker 'tags' to use, then invoke the build/test/publish workflow.
 
 on:
   push:
@@ -28,10 +28,6 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}} # major.minor.patch
             type=semver,pattern={{major}}.{{minor}}
-
-      - name: debug
-        run: |
-          echo steps.meta.outputs.tags ${{ steps.meta.outputs.tags }}
 
     outputs:
       tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,41 @@
+---
+name: Run precommit and conditionally build container
+
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - 'v[0-9]+\.[0-9]+\.[0-9]+'
+  pull_request:
+    branches:
+      - '*'
+
+env:
+  IMAGE_PATH: ghcr.io/${{ github.repository }}
+
+jobs:
+  get-tags:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4.1.1
+        with:
+          images: ${{ env.IMAGE_PATH }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}} # major.minor.patch
+            type=semver,pattern={{major}}.{{minor}}
+
+    outputs:
+      meta_json: ${{ steps.meta.outputs.json }}
+
+  docker-build:
+    needs: get-tags
+    uses: "./.github/workflows/docker_build.yml"
+    with:
+      IMAGE_REFERENCES: ${{ fromJSON(needs.get-tags.outputs.meta_json).tags }}
+
+...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,6 @@ jobs:
     needs: get-tags
     uses: "./.github/workflows/docker_build.yml"
     with:
-      IMAGE_REFERENCES: ${{ toJSON(fromJSON(needs.get-tags.outputs.meta_json).tags) }}
+      IMAGE_REFERENCES: ${{ toJSON(fromJSON(needs.get-tags.outputs.meta_json).tags)} }}
 
 ...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,6 @@ jobs:
     needs: get-tags
     uses: "./.github/workflows/docker_build.yml"
     with:
-      IMAGE_REFERENCES: ${{ fromJSON(needs.get-tags.outputs.meta_json).tags }}
+      IMAGE_REFERENCES: ${{ toJSON(fromJSON(needs.get-tags.outputs.meta_json).tags) }}
 
 ...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,12 +30,12 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
 
     outputs:
-      meta_json: ${{ steps.meta.outputs.json }}
+      tags: ${{ steps.meta.tags }}
 
   docker-build:
     needs: get-tags
     uses: "./.github/workflows/docker_build.yml"
     with:
-      IMAGE_REFERENCES: ${{ toJSON(fromJSON(needs.get-tags.outputs.meta_json).tags) }}
+      IMAGE_REFERENCES: ${{ needs.get-tags.outputs.tags }}
 
 ...

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -26,7 +26,7 @@ on:
         default: 0
     outputs:
       trivy_conclusion:
-        description: "The pass/fail return code from Trivy"
+        description: "The pass/fail status from Trivy"
         value: ${{ jobs.trivy.outputs.trivy_conclusion }}
 
 env:

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -87,4 +87,7 @@ jobs:
         with:
           sarif_file: ${{ env.sarif_file_name  }}
           wait-for-processing: true
+
+    outputs:
+      trivy_conclusion: steps.trivy.outputs.conclusion
 ...

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -98,5 +98,5 @@ jobs:
           wait-for-processing: true
 
     outputs:
-      trivy_conclusion: steps.trivy.conclusion
+      trivy_conclusion: ${{ steps.trivy.conclusion }}
 ...

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -24,6 +24,10 @@ on:
         required: false
         type: number
         default: 0
+    outputs:
+      trivy_conclusion:
+        description: "The pass/fail return code from Trivy"
+        value: ${{ jobs.trivy.outputs.trivy_conclusion }}
 
 env:
   sarif_file_name: trivy-results.sarif
@@ -94,5 +98,5 @@ jobs:
           wait-for-processing: true
 
     outputs:
-      trivy_conclusion: steps.trivy.outputs.conclusion
+      trivy_conclusion: steps.trivy.conclusion
 ...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -67,9 +67,10 @@ jobs:
 
   update-image:
     needs: [get-image-reference, bump-tag]
+    if: ${{!cancelled() && needs.periodic-scan.outputs.trivy_conclusion == 'failure' }}
     uses: "./.github/workflows/docker_build.yml"
     with:
       REF_TO_CHECKOUT: ${{ needs.bump-tag.outputs.new_tag }}
-      IMAGE_REFERENCES: "[${{ needs.get-image-reference.outputs.image_repo }}:${{ needs.bump-tag.outputs.new_version }}, \
-        ${{ needs.get-image-reference.outputs.image_repo }}:${{ needs.bump-tag.outputs.new_major_minor }}]"
+      IMAGE_REFERENCES: "${{ needs.get-image-reference.outputs.image_repo }}:${{ needs.bump-tag.outputs.new_version }},\
+        ${{ needs.get-image-reference.outputs.image_repo }}:${{ needs.bump-tag.outputs.new_major_minor }}"
 ...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -38,15 +38,15 @@ jobs:
   update-image:
     needs: periodic-scan
     runs-on: ubuntu-latest
-    if: ${{ always() }}
-    #if: ${{!cancelled() && needs.periodic-scan.outputs.trivy_conclusion == 'failure' }}
+    #if: ${{ always() }}
+    if: ${{!cancelled() && needs.periodic-scan.outputs.trivy_conclusion == 'failure' }}
     # tag the repo to trigger a new build
     steps:
       - name: Bump version and push tag
         id: tag_version
-        run: |
-          echo "trivy_conclusion " ${{ needs.periodic-scan.outputs.trivy_conclusion }}
-        #uses: mathieudutour/github-tag-action@v6.2
-        #with:
-        #  github_token: ${{ secrets.GITHUB_TOKEN }}
+        #run: |
+        #  echo "trivy_conclusion " ${{ needs.periodic-scan.outputs.trivy_conclusion }}
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 ...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -15,24 +15,21 @@ jobs:
   get-image-reference:
     runs-on: ubuntu-latest
     steps:
-      - name: Get image reference
-        id: image_ref
+      - name: Convert repo' name to lower case
+        id: to_lower_case
         run: |
           # While GitHub repo's can be mixed (upper and lower) case,
           # Docker images can only be lower case
           repo_name=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
-          basic_creds=$(echo "dummy-user-name:${{ github.token }}" | base64)
-          token_response=$(curl -H "Authorization: Basic ${basic_creds}" "https://ghcr.io/token?service=ghcr.io&scope=${repo_name}:pull")
-          echo token_response ${token_response}
-          bearer_token=$(echo ${token_response} | jq -r '.token' )
-          echo bearer_token ${bearer_token}
-          echo $(curl -H "Authorization: Bearer ${bearer_token}" "https://ghcr.io/v2/${repo_name}/tags/list?page_size=1000")
-          last_tag=$(curl -H "Authorization: Bearer ${bearer_token}" "https://ghcr.io/v2/${repo_name}/tags/list?page_size=1000" | jq -r '.tags[-1]')
-          echo "repo_name=$repo_name" >> $GITHUB_ENV
-          echo "last_tag=$last_tag" >> $GITHUB_ENV
+      - name: Find current version
+        id: find_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dry_run: true #setting to 'true' means no new version is created
     outputs:
       image_repo: ghcr.io/${{ env.repo_name }}
-      image_tag: ${{ env.last_tag }}
+      image_tag: ${{ steps.find_version.outputs.previous_version }}
 
   periodic-scan:
     needs: get-image-reference

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -21,6 +21,7 @@ jobs:
           # While GitHub repo's can be mixed (upper and lower) case,
           # Docker images can only be lower case
           repo_name=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+          echo "repo_name=$repo_name" >> $GITHUB_ENV
       - name: Find current version
         id: find_version
         uses: mathieudutour/github-tag-action@v6.2

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -9,8 +9,10 @@ name: Trivy Periodic Image Scan
 
 on:
   schedule:
+    # run hourly (testing)
+    - cron: "0 * * * *"
     # run daily
-    - cron: "0 0 * * *"
+    #- cron: "0 0 * * *"
 
 jobs:
   to-lower-case:

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -66,7 +66,7 @@ jobs:
       new_major_minor: ${{ steps.parsed.outputs.major }}.${{ steps.parsed.outputs.minor }}
 
   update-image:
-    needs: [get-image-reference, bump-tag]
+    needs: [get-image-reference, periodic-scan, bump-tag]
     if: ${{!cancelled() && needs.periodic-scan.outputs.trivy_conclusion == 'failure' }}
     uses: "./.github/workflows/docker_build.yml"
     with:

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -38,12 +38,15 @@ jobs:
   update-image:
     needs: periodic-scan
     runs-on: ubuntu-latest
-    if: ${{!cancelled() && needs.periodic-scan.outputs.trivy_conclusion == 'failure' }}
+    if: ${{ always() }}
+    #if: ${{!cancelled() && needs.periodic-scan.outputs.trivy_conclusion == 'failure' }}
     # tag the repo to trigger a new build
     steps:
       - name: Bump version and push tag
         id: tag_version
-        uses: mathieudutour/github-tag-action@v6.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "trivy_conclusion " ${{ needs.periodic-scan.outputs.trivy_conclusion }}
+        #uses: mathieudutour/github-tag-action@v6.2
+        #with:
+        #  github_token: ${{ secrets.GITHUB_TOKEN }}
 ...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -32,4 +32,18 @@ jobs:
       # While GitHub repo's can be mixed (upper and lower) case,
       # Docker images can only be lower case
       IMAGE_NAME: ${{ needs.to-lower-case.outputs.lowercase-repo-name }}
+      EXIT_CODE: 1
+
+  # If scan failed, rebuild the image
+  update-image:
+    needs: periodic-scan
+    runs-on: ubuntu-latest
+    if: ${{needs.periodic-scan.outputs.trivy_conclusion == 'failure' }}
+    # tag the repo to trigger a new build
+    steps:
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 ...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -9,44 +9,67 @@ name: Trivy Periodic Image Scan
 
 on:
   schedule:
-    # run daily
-    - cron: "0 0 * * *"
+    - cron: "0 * * * *"     # run hourly
+    #- cron: "0 0 * * *"     # run daily
 
 jobs:
-  to-lower-case:
+  get-image-reference:
     runs-on: ubuntu-latest
     steps:
-      - name: Ensure image name is lower case
-        id: repo_name
-        uses: vishalmamidi/lowercase-action@v1
-        with:
-          string: ghcr.io/${{ github.repository }}:main
+      - name: Get image reference
+        id: image_ref
+        run: |
+          # While GitHub repo's can be mixed (upper and lower) case,
+          # Docker images can only be lower case
+          repo_name=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
+          basic_creds=$(echo "dummy-user-name:${{ github.token }}" | base64)
+          token_response=$(curl -H "Authorization: Basic ${basic_creds}" "https://ghcr.io/token?service=ghcr.io&scope=${repo_name}:pull")
+          echo token_response ${token_response}
+          bearer_token=$(echo ${token_response} | jq -r '.token' )
+          echo bearer_token ${bearer_token}
+          echo $(curl -H "Authorization: Bearer ${bearer_token}" "https://ghcr.io/v2/${repo_name}/tags/list?page_size=1000")
+          last_tag=$(curl -H "Authorization: Bearer ${bearer_token}" "https://ghcr.io/v2/${repo_name}/tags/list?page_size=1000" | jq -r '.tags[-1]')
+          echo "repo_name=$repo_name" >> $GITHUB_ENV
+          echo "last_tag=$last_tag" >> $GITHUB_ENV
     outputs:
-      lowercase-repo-name: ${{ steps.repo_name.outputs.lowercase }}
+      image_repo: ghcr.io/${{ env.repo_name }}
+      image_tag: ${{ env.last_tag }}
 
   periodic-scan:
-    needs: to-lower-case
+    needs: get-image-reference
     uses: "./.github/workflows/trivy.yml"
     with:
       SOURCE_TYPE: image
-      # While GitHub repo's can be mixed (upper and lower) case,
-      # Docker images can only be lower case
-      IMAGE_NAME: ${{ needs.to-lower-case.outputs.lowercase-repo-name }}
+      IMAGE_NAME: ${{ needs.get-image-reference.outputs.image_repo }}:${{ needs.get-image-reference.outputs.image_tag }}
       EXIT_CODE: 1
 
-  # If scan failed, rebuild the image
-  update-image:
+  # If scan failed, bump tag and rebuild the image
+  bump-tag:
     needs: periodic-scan
     runs-on: ubuntu-latest
-    #if: ${{ always() }}
     if: ${{!cancelled() && needs.periodic-scan.outputs.trivy_conclusion == 'failure' }}
     # tag the repo to trigger a new build
     steps:
       - name: Bump version and push tag
         id: tag_version
-        #run: |
-        #  echo "trivy_conclusion " ${{ needs.periodic-scan.outputs.trivy_conclusion }}
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: parse new version
+        id: parsed
+        uses: booxmedialtd/ws-action-parse-semver@v1
+        with:
+          input_string: ${{ steps.tag_version.outputs.new_version }}
+    outputs:
+      new_tag: ${{ steps.tag_version.outputs.new_tag }}
+      new_version: ${{ steps.tag_version.outputs.new_version }}
+      new_major_minor: ${{ steps.parsed.outputs.major }}.${{ steps.parsed.outputs.minor }}
+
+  update-image:
+    needs: [get-image-reference, bump-tag]
+    uses: "./.github/workflows/docker_build.yml"
+    with:
+      REF_TO_CHECKOUT: ${{ needs.bump-tag.outputs.new_tag }}
+      IMAGE_REFERENCES: "[${{ needs.get-image-reference.outputs.image_repo }}:${{ needs.bump-tag.outputs.new_version }}, \
+        ${{ needs.get-image-reference.outputs.image_repo }}:${{ needs.bump-tag.outputs.new_major_minor }}]"
 ...

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -9,10 +9,8 @@ name: Trivy Periodic Image Scan
 
 on:
   schedule:
-    # run hourly (testing)
-    - cron: "0 * * * *"
     # run daily
-    #- cron: "0 0 * * *"
+    - cron: "0 0 * * *"
 
 jobs:
   to-lower-case:

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -9,8 +9,7 @@ name: Trivy Periodic Image Scan
 
 on:
   schedule:
-    - cron: "0 * * * *"     # run hourly
-    #- cron: "0 0 * * *"     # run daily
+    - cron: "0 0 * * *"     # run daily
 
 jobs:
   get-image-reference:

--- a/.github/workflows/trivy_periodic_image_scan.yml
+++ b/.github/workflows/trivy_periodic_image_scan.yml
@@ -38,7 +38,7 @@ jobs:
   update-image:
     needs: periodic-scan
     runs-on: ubuntu-latest
-    if: ${{needs.periodic-scan.outputs.trivy_conclusion == 'failure' }}
+    if: ${{!cancelled() && needs.periodic-scan.outputs.trivy_conclusion == 'failure' }}
     # tag the repo to trigger a new build
     steps:
       - name: Bump version and push tag


### PR DESCRIPTION
When a daily Trivy scan fails, we want to generate a new patch version (say, advance from `1.1.2` to `1.1.3`), build and test that version then, if the new version passes Trivy, publish the Docker image.

Previously the daily scan simply scanned the `main` Docker tag (which was built from the head of the `main` branch), but this isn't quite right, since the head of `main` might be different from the latest tag (`1.1.2`).  So we added the `get-image-reference` job to `trivy_periodic_image_scan.yml` to find the latest tag, which we then use to determine what container image to scan.

When a Trivy scan fails we create a new tag.  We expected the new tag to kick off a new build, but GitHub does not allow events generated in a workflow to trigger another workflow.  (This is to avoid infinite loops.) So we need to explicitly invoke the `docker_build.yml` workflow.  To do this we refactored the workflow so that it can be called either by a PR or merge (from the new  `main.yml` entrypoint) or from the `trivy_periodic_image_scan.yml` entrypoint. Each entrypoint determines (1) what GitHub tag to checkout and (2) what Docker tags to publish to, and passes them along to the `docker_build.yml` workflow.